### PR TITLE
Use high level I2C clock setting function to allow portability.

### DIFF
--- a/MPR121/MPR121.cpp
+++ b/MPR121/MPR121.cpp
@@ -126,11 +126,11 @@ bool MPR121_t::begin(unsigned char address){
 }
 
 void MPR121_t::goSlow(){
-	TWBR = ((F_CPU / 100000L) - 16) / 2; // set I2C clock to 100kHz
+	Wire.setClock(100000L); // set I2C clock to 100kHz
 }
 
 void MPR121_t::goFast(){
-	TWBR = ((F_CPU / 400000L) - 16) / 2; // set I2C clock to 400kHz
+    Wire.setClock(400000L); // set I2C clock to 400kHz
 }
 
 void MPR121_t::run(){


### PR DESCRIPTION
Most of the code is using the Wire library to set up the I2C.
But the use of TWBR register to set I2C clock speed was not portable.
This fix makes it compatible with other architecture as long as it supports the Wire lib.
Now it should also compile with ARM and Tensilica architectures (tested with Teensy 3.x and ESP8266).
