### PR TITLE
Adapt to esp8266

### DIFF
--- a/MPR121/MPR121.cpp
+++ b/MPR121/MPR121.cpp
@@ -50,7 +50,6 @@ extern "C" {
 #define OUT_OF_RANGE_BIT 4
 
 MPR121_t::MPR121_t(){
-	Wire.begin();	
 	address = 0x5C;    // default address is 0x5C, for use with Bare Touch Board
 	ECR_backup = 0x00;
 	running = false;

--- a/MPR121/MPR121.h
+++ b/MPR121/MPR121.h
@@ -196,14 +196,11 @@ enum mpr121_sample_interval_t
 class MPR121_t
 {		
 	public:
-		MPR121_t();
-
 		// -------------------- BASIC FUNCTIONS --------------------
 
 		// begin() must be called before using any other function
 		// address is optional, default is 0x5C
-		bool begin(unsigned char address);
-		bool begin();
+		bool begin(unsigned char address = 0x5C);
 
 		// I2C speed control functions - goFast() sets the SCL clock
 		// to 400kHz - goSlow() sets the SCL clock to 100kHz. Defaults


### PR DESCRIPTION
On the ESP8266 Arduino framework the constructor causes a crash, a simple workaround is to eliminate the need for it. The patches I created are an option for that.

I have to admit I didn't fully test the error handling, it's mainly a basis for consideration.