### PR TITLE
fix the issue of conflicting types that occur with ArduinoCore-samd, …

### DIFF
--- a/MPR121/MPR121.cpp
+++ b/MPR121/MPR121.cpp
@@ -93,7 +93,7 @@ void MPR121_type::setRegister(uint8_t reg, uint8_t value){
 }
 
 uint8_t MPR121_type::getRegister(uint8_t reg){
-  uint8_t scratch;
+    uint8_t scratch = 0;
 
     Wire.beginTransmission(address);
     Wire.write(reg); // set address to read from our requested register
@@ -786,7 +786,7 @@ void MPR121_type::pinMode(uint8_t electrode, mpr121_pinf_type mode){
   uint8_t bitmask = 1<<(electrode-4);
 
   switch(mode){
-    case INPUT_PULLDOWN:
+    case mpr121_pinf_type::INPUT_PULLDOWN:
       // MPR121_EN = 1
       // MPR121_DIR = 0
       // MPR121_CTL0 = 1
@@ -797,7 +797,7 @@ void MPR121_type::pinMode(uint8_t electrode, mpr121_pinf_type mode){
       setRegister(MPR121_CTL1, getRegister(MPR121_CTL1) & ~bitmask);
       break;
 
-    case OUTPUT_HIGHSIDE:
+    case mpr121_pinf_type::OUTPUT_HIGHSIDE:
       // MPR121_EN = 1
       // MPR121_DIR = 1
       // MPR121_CTL0 = 1
@@ -808,7 +808,7 @@ void MPR121_type::pinMode(uint8_t electrode, mpr121_pinf_type mode){
       setRegister(MPR121_CTL1, getRegister(MPR121_CTL1) | bitmask);
       break;
 
-    case OUTPUT_LOWSIDE:
+    case mpr121_pinf_type::OUTPUT_LOWSIDE:
       // MPR121_EN = 1
       // MPR121_DIR = 1
       // MPR121_CTL0 = 1

--- a/MPR121/MPR121.h
+++ b/MPR121/MPR121.h
@@ -146,7 +146,7 @@ struct MPR121_settings_type
 };
 
 // GPIO pin function constants
-enum mpr121_pinf_type
+enum class mpr121_pinf_type
 {
   // INPUT and OUTPUT (and others) are already defined by Arduino, use its definitions if they exist
 #ifndef INPUT

--- a/MPR121/MPR121_Datastream.cpp
+++ b/MPR121/MPR121_Datastream.cpp
@@ -55,12 +55,13 @@ void reset() {
   #endif
 }
 
-char *splitString(char *data, char *separator, int index) {
+char *splitString(char *data, const char *separator, int index) {
   char *act, *sub, *ptr;
   static char copy[255];
   int i;
 
   strcpy(copy, data);
+  sub = copy; // to supress the warning 
 
   for (i = 0, act = copy; i <= index; i++, act = NULL) {
     sub = strtok_r(act, separator, &ptr);


### PR DESCRIPTION
…and a few improvements.

I did some fixes to the code to make it possible to work with Arduino MKR1000, and I guess it's going to work well with any platform based on ArduinoCore because it uses "PinMode" user-defined type, thus I made mpr121_pinf_type a strong type by providing a class keyword with enum.

I've tested on Arduino MKR1000 and Arduino UNO and work like a charm.