### PR TITLE
Include cstdint in MPR121_defs.h

### DIFF
--- a/MPR121/MPR121_defs.h
+++ b/MPR121/MPR121_defs.h
@@ -37,6 +37,8 @@
 #ifndef MPR121_DEFS_H
 #define MPR121_DEFS_H
 
+#include <cstdint>
+
 // MPR121 Register Defines
 
 // touch and OOR statuses


### PR DESCRIPTION
Add missing cstdint to MPR121_defs.h for modern toolchains